### PR TITLE
Changes Guzzle adapter dependency to support PHP 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "spiral/composer-publish-plugin": false
+            "spiral/composer-publish-plugin": false,
+            "php-http/discovery": false
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "spiral/boot": "^3.2",
         "spiral/console": "^3.2",
         "spiral/telemetry": "^3.3",
-        "open-telemetry/sdk": "^0.0.17",
-        "php-http/guzzle6-adapter": "~2"
+        "open-telemetry/sdk": "^0.0.17"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "spiral/boot": "^3.2",
         "spiral/console": "^3.2",
         "spiral/telemetry": "^3.3",
-        "open-telemetry/sdk": "^0.0.17"
+        "open-telemetry/sdk": "^0.0.17",
+        "php-http/guzzle7-adapter": "~1"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",


### PR DESCRIPTION
Guzzle HTTP Client before version 7.5.0 did not support PHP 8.2. This pull request replaces `php-http/guzzle6-adapter` with `php-http/guzzle7-adapter` so that this package supports PHP 8.2.