### PR TITLE
Removing Parser binding

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -12,7 +12,5 @@ jobs:
     with:
       os: >-
         ['ubuntu-latest']
-      php: >-
-        ['8.1', '8.2']
       stability: >-
         ['prefer-lowest', 'prefer-stable']

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -12,5 +12,3 @@ jobs:
     with:
       os: >-
         ['ubuntu-latest']
-      php: >-
-        ['8.1']

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "spiral/events": "^3.2",
         "spiral/boot": "^3.2",
         "spiral/telemetry": "^3.3",
-        "open-telemetry/sdk": "^0.0.17"
+        "open-telemetry/sdk": "^1.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",

--- a/src/Bootloader/OpenTelemetryBootloader.php
+++ b/src/Bootloader/OpenTelemetryBootloader.php
@@ -7,8 +7,6 @@ namespace Spiral\OpenTelemetry\Bootloader;
 use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
-use OpenTelemetry\SDK\Common\Dsn\Parser;
-use OpenTelemetry\SDK\Common\Dsn\ParserInterface;
 use OpenTelemetry\SDK\Trace\ExporterFactory;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use OpenTelemetry\SDK\Trace\SpanProcessorFactory;
@@ -29,7 +27,6 @@ final class OpenTelemetryBootloader extends Bootloader
         TracerInterface::class => [self::class, 'initTracer'],
         TracerProviderInterface::class => [self::class, 'initTraceProvider'],
         SpanExporterInterface::class => [self::class, 'initSpanExporter'],
-        ParserInterface::class => Parser::class,
         TextMapPropagatorInterface::class => [self::class, 'initTextMapPropagator'],
     ];
 

--- a/tests/src/Bootloader/OpenTelemetryBootloaderTest.php
+++ b/tests/src/Bootloader/OpenTelemetryBootloaderTest.php
@@ -7,17 +7,12 @@ namespace Spiral\OpenTelemetry\Tests\Bootloader;
 use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
-use OpenTelemetry\SDK\Common\Dsn\ParserInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use OpenTelemetry\SDK\Trace\TracerProviderInterface;
 use Spiral\OpenTelemetry\Tests\TestCase;
 use OpenTelemetry\SDK\Trace\Tracer;
 use Spiral\OpenTelemetry\Trace\DeferredSpanExporter;
-use OpenTelemetry\SDK\Common\Dsn\Parser;
-use Spiral\Telemetry\Config\TelemetryConfig;
-use Spiral\Telemetry\NullTracerFactory;
-use Spiral\Telemetry\LogTracerFactory;
 
 class OpenTelemetryBootloaderTest extends TestCase
 {
@@ -34,11 +29,6 @@ class OpenTelemetryBootloaderTest extends TestCase
     public function testSpanExporterInterfaceBinding(): void
     {
         $this->assertContainerBound(SpanExporterInterface::class, DeferredSpanExporter::class);
-    }
-
-    public function testParserInterfaceBinding(): void
-    {
-        $this->assertContainerBound(ParserInterface::class, Parser::class);
     }
 
     public function testTextMapPropagatorInterfaceBinding(): void


### PR DESCRIPTION
The `OpenTelemetry\SDK\Common\Dsn\Parser` was removed in the release: 1.0.0beta16 https://github.com/open-telemetry/opentelemetry-php/pull/1099/files 