### PR TITLE
Fixes a bug with array_intersect_ukey

### DIFF
--- a/src/TracerFactory.php
+++ b/src/TracerFactory.php
@@ -23,7 +23,13 @@ final class TracerFactory implements TracerFactoryInterface
         $context = \array_intersect_ukey(
             $context,
             \array_flip($this->propagator->fields()),
-            static fn(string $key1, string $key2): int => (\strtolower($key1) === \strtolower($key2)) ? 0 : -1,
+            static function(string $key1, string $key2): int {
+                if (\strtolower($key1) === \strtolower($key2)) {
+                    return 0;
+                }
+
+                return \strtolower($key1) > \strtolower($key2) ? 1 : -1;
+            },
         );
 
         return new Tracer($this->scope, $this->tracer, $this->propagator, $context);

--- a/tests/src/TracerFactoryTest.php
+++ b/tests/src/TracerFactoryTest.php
@@ -25,4 +25,28 @@ class TracerFactoryTest extends TestCase
 
         $this->assertInstanceOf(TelemetryTracerInterface::class, $factory->make(['foo' => 'bar']));
     }
+
+    public function testMakePropagatesContext(): void
+    {
+        $factory = new TracerFactory(
+            m::mock(ScopeInterface::class),
+            m::mock(TracerInterface::class),
+            $propagator = m::mock(TextMapPropagatorInterface::class)
+        );
+
+        $propagator->shouldReceive('fields')->withNoArgs()->andReturn(['foo3', 'foo4', 'foo5']);
+
+        $tracer = $factory->make([
+            'foo1' => 'bar1',
+            'foo2' => 'bar2',
+            'foo3' => 'bar3',
+            'foo4' => 'bar4',
+            'foo5' => 'bar5',
+            'foo6' => 'bar6',
+        ]);
+
+        $propagated = ['foo3' => 'bar3', 'foo4' => 'bar4', 'foo5' => 'bar5'];
+
+        $this->assertEquals($propagated, $tracer->getContext());
+    }
 }


### PR DESCRIPTION
This fixes a bug where user-defined compare func should have been a proper string comparison func. Always returning -1 breaks the intersect function.